### PR TITLE
Achievements not updating

### DIFF
--- a/.github/workflows/steam-beta-publish.yml
+++ b/.github/workflows/steam-beta-publish.yml
@@ -23,10 +23,10 @@ jobs:
       run: |
         pwd; cd ~/work/$REPO_ROOT/$REPO_DEPOT1
         wget https://dl.nwjs.io/v0.49.2/nwjs-sdk-v0.49.2-win-x64.zip
-        unzip nwjs-sdk-v0.49.2-win-x64.zip
-        rm ./nwjs-sdk-v0.49.2-win-x64/chromedriver.exe
-        mv ./nwjs-sdk-v0.49.2-win-x64/* ./
-        rmdir ./nwjs-sdk-v0.49.2-win-x64
+        unzip nwjs-sdk-v0.55.0-win-x64.zip
+        rm ./nwjs-sdk-v0.55.0-win-x64/chromedriver.exe
+        mv ./nwjs-sdk-v0.55.0-win-x64/* ./
+        rmdir ./nwjs-sdk-v0.55.0-win-x64
         mv ./nw.exe ./Game.exe
         ls -l ~/work/$REPO_ROOT/$REPO_DEPOT1
 

--- a/.github/workflows/steam-beta-publish.yml
+++ b/.github/workflows/steam-beta-publish.yml
@@ -22,7 +22,12 @@ jobs:
     - name: Add build dependancies
       run: |
         pwd; cd ~/work/$REPO_ROOT/$REPO_DEPOT1
-        tar xvzf .github/deployment/artifacts.tar.gz
+        wget https://dl.nwjs.io/v0.49.2/nwjs-sdk-v0.49.2-win-x64.zip
+        unzip nwjs-sdk-v0.49.2-win-x64.zip
+        rm ./nwjs-sdk-v0.49.2-win-x64/chromedriver.exe
+        mv ./nwjs-sdk-v0.49.2-win-x64/* ./
+        rmdir ./nwjs-sdk-v0.49.2-win-x64
+        mv ./nw.exe ./Game.exe
         ls -l ~/work/$REPO_ROOT/$REPO_DEPOT1
 
     - name: Cleanup build environment

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
-file*.rmmzsave
+package.json
+save/*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Kin's Chronicle
 
+## How to Contribute
+1. RPG Maker MZ v1.70  
+1. NW.js v0.55.0 SDK winx64 @ https://dl.nwjs.io/v0.55.0/nwjs-sdk-v0.55.0-win-x64.zip  
+   1. Place the contents of the above ZIP in your "RPG Maker MZ\nwjs-win" folder, overwriting the contents
+
+# Credits
 ## Story
 Consulting by Brent Fisher @ https://www.brentfisher.net/
 
 ## Music
-Composed and mastered by Jeremy Palmer
+Composed and mastered by Jeremy Palmer of Life Lucid @ https://linktr.ee/lifelucid
 
 ## Art
 Librarium Animated Battlers from Aekashics @ http://akashics.moe/  
@@ -19,11 +25,11 @@ VisuStella™: Armory Axe and Staff [Copyright](C) 2021 VisuStella™
 VisuStella™: Armory Bow and Club [Copyright](C) 2021 VisuStella™  
 VisuStella™: Armory Katana and Katar [Copyright](C) 2021 VisuStella™  
 VisuStella™: Armory Sword and Spear [Copyright](C) 2021 VisuStella™  
-VisuStella™: Atelier Potions and Tonics [Copyright](C) VisuStella, LLC  
+VisuStella™: Atelier Potions and Tonics [Copyright](C) VisuStella, LLC    - 
 http://www.visustella.com/  
 
 ## Coding and Support
-VisustellaMZ @ http://www.visustella.com/  
+VisustellaMZ @ http://www.visustella.com/    - 
 MZ3D by CutieVirus @ https://cutievirus.itch.io/  
 HUD Maker Ultra Pro by SumRndmDde @ http://sumrndm.site/  
 Battle HUD by Moghunter @ https://mogplugins.wordpress.com/  


### PR DESCRIPTION
Updated NW.js to v0.55.0 to bring back into sync with greenworks for proper Steam integration. Reversion was caused by upgrade to RPG Maker MZ itself.

Changed from using a prebuild archive to just downloading it directly from the source provider in actions. Also updated README.md to include a contribution section on how to make that work for anyone wanting to test/contribute.